### PR TITLE
fix: deployment environment tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ EigenX collects anonymous usage data to help us improve the CLI and understand h
 - Performance metrics (command execution times)
 - System information (OS, architecture)
 - Geographic location (country/city level only)
+- Deployment environment (e.g., sepolia, mainnet-alpha)
 
 ### What We DON'T Collect
 

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -311,11 +311,8 @@ func WithCommandMetricsContext(ctx *cli.Context) error {
 	metrics := telemetry.NewMetricsContext()
 	ctx.Context = telemetry.WithMetricsContext(ctx.Context, metrics)
 
-	// Get environment name for metrics
-	environment := getEnvironmentForMetrics(ctx)
-
 	// Set environment in metrics
-	metrics.Properties["environment"] = environment
+	metrics.Properties["environment"] = getEnvironmentForMetrics(ctx)
 
 	// Set appEnv details in metrics
 	if appEnv, ok := common.AppEnvironmentFromContext(ctx.Context); ok {


### PR DESCRIPTION
Previously, deployment environment was always set to `sepolia`, unless the `--environment` flag was passed.