### PR TITLE
feat: add npm distribution with platform-specific optional dependencies

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -90,8 +90,28 @@ jobs:
           echo "$VERSION" > VERSION_DEV
           aws s3 cp VERSION_DEV "s3://eigenlayer-eigenx-releases-dev/VERSION" --content-type "text/plain"
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Prepare npm packages
+        run: |
+          echo "Preparing npm packages for version $VERSION..."
+          VERSION=$VERSION make npm-prepare
+
+      - name: Publish to npm (dev tag)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo "Publishing to npm with 'dev' tag..."
+          make npm-publish-dev
+
       - name: Summary
         run: |
           echo "✅ Dev release $VERSION deployed successfully!"
           echo "📦 Artifacts uploaded to: s3://eigenlayer-eigenx-releases-dev/$VERSION/"
+          echo "📦 npm packages published with tag 'dev'"
           echo "🔗 Install with: curl -sSL install-script | bash -s -- --dev"
+          echo "🔗 Or via npm: npm install -g @layr-labs/eigenx@dev"

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -168,10 +168,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Uploading built artifacts to GitHub release..."
-          
+
           echo "Upload URL: ${{ steps.create_release.outputs.upload_url }}"
           export upload_url=$(echo "${{ steps.create_release.outputs.upload_url }}" | sed -e "s/{?name,label}//")
-      
+
           for asset_name in $(ls ./release | grep -E '\.(tar\.gz|zip)$');
           do
             asset="./release/${asset_name}"
@@ -183,12 +183,32 @@ jobs:
               "${upload_url}?name=$asset_name"
           done
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Prepare npm packages
+        run: |
+          echo "Preparing npm packages for version $VERSION..."
+          VERSION=$VERSION make npm-prepare
+
+      - name: Publish to npm (latest tag)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo "Publishing to npm with 'latest' tag..."
+          make npm-publish-prod
+
       - name: Summary
         run: |
           echo "🚀 Production release $VERSION deployed successfully!"
           echo "📦 Built fresh production binary with clean version"
           echo "🔒 Verified dev testing completed with matching commit"
+          echo "📦 npm packages published with tag 'latest'"
           echo "🔗 Users can install with: curl -sSL install-script | bash"
+          echo "🔗 Or via npm: npm install -g @layr-labs/eigenx"
           echo "📋 GitHub release: https://github.com/${{ github.repository }}/releases/tag/$VERSION"
 
   smoke-test-binaries:

--- a/Makefile
+++ b/Makefile
@@ -76,3 +76,52 @@ release:
 	$(MAKE) build/linux-amd64
 	$(MAKE) build/windows-amd64
 	$(MAKE) build/windows-arm64
+
+.PHONY: npm-prepare
+npm-prepare: ## Prepare npm packages with binaries (run after 'make release')
+	@echo "Copying binaries to npm packages..."
+	@mkdir -p npm/eigenx-darwin-arm64/bin
+	@mkdir -p npm/eigenx-darwin-amd64/bin
+	@mkdir -p npm/eigenx-linux-arm64/bin
+	@mkdir -p npm/eigenx-linux-amd64/bin
+	@mkdir -p npm/eigenx-windows-amd64/bin
+	@mkdir -p npm/eigenx-windows-arm64/bin
+	@cp release/darwin-arm64/eigenx npm/eigenx-darwin-arm64/bin/
+	@cp release/darwin-amd64/eigenx npm/eigenx-darwin-amd64/bin/
+	@cp release/linux-arm64/eigenx npm/eigenx-linux-arm64/bin/
+	@cp release/linux-amd64/eigenx npm/eigenx-linux-amd64/bin/
+	@cp release/windows-amd64/eigenx.exe npm/eigenx-windows-amd64/bin/
+	@cp release/windows-arm64/eigenx.exe npm/eigenx-windows-arm64/bin/
+	@echo "Updating package.json versions to $(VERSION)..."
+	@command -v jq >/dev/null 2>&1 || { echo "Error: jq is required but not installed"; exit 1; }
+	@for pkg in npm/eigenx npm/eigenx-darwin-arm64 npm/eigenx-darwin-amd64 npm/eigenx-linux-arm64 npm/eigenx-linux-amd64 npm/eigenx-windows-amd64 npm/eigenx-windows-arm64; do \
+		jq '.version = "$(VERSION)"' $$pkg/package.json > $$pkg/package.json.tmp && mv $$pkg/package.json.tmp $$pkg/package.json; \
+	done
+	@jq '.optionalDependencies = (.optionalDependencies | to_entries | map(.value = "$(VERSION)") | from_entries)' npm/eigenx/package.json > npm/eigenx/package.json.tmp && mv npm/eigenx/package.json.tmp npm/eigenx/package.json
+	@echo "✓ npm packages prepared successfully"
+
+.PHONY: npm-publish-prod
+npm-publish-prod: ## Publish npm packages to production (latest tag)
+	@echo "Publishing platform-specific packages to npm with 'latest' tag..."
+	@cd npm/eigenx-darwin-arm64 && npm publish --access public --tag latest
+	@cd npm/eigenx-darwin-amd64 && npm publish --access public --tag latest
+	@cd npm/eigenx-linux-arm64 && npm publish --access public --tag latest
+	@cd npm/eigenx-linux-amd64 && npm publish --access public --tag latest
+	@cd npm/eigenx-windows-amd64 && npm publish --access public --tag latest
+	@cd npm/eigenx-windows-arm64 && npm publish --access public --tag latest
+	@echo "Publishing main package to npm with 'latest' tag..."
+	@cd npm/eigenx && npm publish --access public --tag latest
+	@echo "✓ All packages published to npm as 'latest'"
+
+.PHONY: npm-publish-dev
+npm-publish-dev: ## Publish npm packages to dev (dev tag)
+	@echo "Publishing platform-specific packages to npm with 'dev' tag..."
+	@cd npm/eigenx-darwin-arm64 && npm publish --access public --tag dev
+	@cd npm/eigenx-darwin-amd64 && npm publish --access public --tag dev
+	@cd npm/eigenx-linux-arm64 && npm publish --access public --tag dev
+	@cd npm/eigenx-linux-amd64 && npm publish --access public --tag dev
+	@cd npm/eigenx-windows-amd64 && npm publish --access public --tag dev
+	@cd npm/eigenx-windows-arm64 && npm publish --access public --tag dev
+	@echo "Publishing main package to npm with 'dev' tag..."
+	@cd npm/eigenx && npm publish --access public --tag dev
+	@echo "✓ All packages published to npm as 'dev'"

--- a/npm/eigenx-darwin-amd64/package.json
+++ b/npm/eigenx-darwin-amd64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@layr-labs/eigenx-darwin-amd64",
+  "version": "0.0.0-development",
+  "description": "eigenx binary for macOS x64",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Layr-Labs/eigenx-cli.git"
+  },
+  "license": "MIT",
+  "os": ["darwin"],
+  "cpu": ["x64"],
+  "files": [
+    "bin/eigenx"
+  ]
+}

--- a/npm/eigenx-darwin-arm64/package.json
+++ b/npm/eigenx-darwin-arm64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@layr-labs/eigenx-darwin-arm64",
+  "version": "0.0.0-development",
+  "description": "eigenx binary for macOS arm64",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Layr-Labs/eigenx-cli.git"
+  },
+  "license": "MIT",
+  "os": ["darwin"],
+  "cpu": ["arm64"],
+  "files": [
+    "bin/eigenx"
+  ]
+}

--- a/npm/eigenx-linux-amd64/package.json
+++ b/npm/eigenx-linux-amd64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@layr-labs/eigenx-linux-amd64",
+  "version": "0.0.0-development",
+  "description": "eigenx binary for Linux x64",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Layr-Labs/eigenx-cli.git"
+  },
+  "license": "MIT",
+  "os": ["linux"],
+  "cpu": ["x64"],
+  "files": [
+    "bin/eigenx"
+  ]
+}

--- a/npm/eigenx-linux-arm64/package.json
+++ b/npm/eigenx-linux-arm64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@layr-labs/eigenx-linux-arm64",
+  "version": "0.0.0-development",
+  "description": "eigenx binary for Linux arm64",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Layr-Labs/eigenx-cli.git"
+  },
+  "license": "MIT",
+  "os": ["linux"],
+  "cpu": ["arm64"],
+  "files": [
+    "bin/eigenx"
+  ]
+}

--- a/npm/eigenx-windows-amd64/package.json
+++ b/npm/eigenx-windows-amd64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@layr-labs/eigenx-windows-amd64",
+  "version": "0.0.0-development",
+  "description": "eigenx binary for Windows x64",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Layr-Labs/eigenx-cli.git"
+  },
+  "license": "MIT",
+  "os": ["win32"],
+  "cpu": ["x64"],
+  "files": [
+    "bin/eigenx.exe"
+  ]
+}

--- a/npm/eigenx-windows-arm64/package.json
+++ b/npm/eigenx-windows-arm64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@layr-labs/eigenx-windows-arm64",
+  "version": "0.0.0-development",
+  "description": "eigenx binary for Windows arm64",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Layr-Labs/eigenx-cli.git"
+  },
+  "license": "MIT",
+  "os": ["win32"],
+  "cpu": ["arm64"],
+  "files": [
+    "bin/eigenx.exe"
+  ]
+}

--- a/npm/eigenx/README.md
+++ b/npm/eigenx/README.md
@@ -1,0 +1,87 @@
+# @layr-labs/eigenx
+
+**Deploy verifiable applications in Trusted Execution Environments (TEEs)**
+
+## Installation
+
+### Global Install (Recommended)
+
+```bash
+npm install -g @layr-labs/eigenx
+```
+
+After installation, the `eigenx` command will be available globally.
+
+### Using npx (No Install Required)
+
+Run eigenx commands without installing:
+
+```bash
+# Run latest version
+npx @layr-labs/eigenx app list
+
+# Pin to specific version
+npx @layr-labs/eigenx@1.2.3 app deploy
+
+# Use dev version
+npx @layr-labs/eigenx@dev app create
+```
+
+**Note:** The first `npx` run downloads the package (~10-20MB). Subsequent runs use the cached version and are much faster. For frequent use, global installation is recommended.
+
+## Usage
+
+```bash
+# Get help
+eigenx --help
+
+# Create a new app
+eigenx app create
+
+# Deploy an app
+eigenx app deploy
+
+# List deployed apps
+eigenx app list
+
+# View app information
+eigenx app info
+
+# View logs
+eigenx app logs
+
+# Start/stop/terminate apps
+eigenx app start
+eigenx app stop
+eigenx app terminate
+
+# Manage app names
+eigenx app name
+```
+
+## Supported Platforms
+
+eigenx provides pre-built binaries for the following platforms:
+
+- **macOS**: arm64 (Apple Silicon), x64 (Intel)
+- **Linux**: arm64, x64
+- **Windows**: x64, arm64
+
+The correct binary for your platform will be automatically installed.
+
+## Requirements
+
+- Node.js 14.0.0 or higher (for installation via npm)
+- Docker (for building and deploying apps)
+
+## Documentation
+
+For detailed documentation, visit the [eigenx-cli repository](https://github.com/Layr-Labs/eigenx-cli).
+
+## Issues
+
+If you encounter any problems, please [open an issue](https://github.com/Layr-Labs/eigenx-cli/issues).
+
+## License
+
+MIT

--- a/npm/eigenx/install.js
+++ b/npm/eigenx/install.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+const { existsSync } = require('fs');
+const { join } = require('path');
+
+// Map Node.js platform/arch to package names
+const PLATFORMS = {
+  'darwin-arm64': '@layr-labs/eigenx-darwin-arm64',
+  'darwin-x64': '@layr-labs/eigenx-darwin-amd64',
+  'linux-arm64': '@layr-labs/eigenx-linux-arm64',
+  'linux-x64': '@layr-labs/eigenx-linux-amd64',
+  'win32-x64': '@layr-labs/eigenx-windows-amd64',
+  'win32-arm64': '@layr-labs/eigenx-windows-arm64'
+};
+
+// Map platform to binary extension
+const BINARY_NAMES = {
+  'darwin-arm64': 'eigenx',
+  'darwin-x64': 'eigenx',
+  'linux-arm64': 'eigenx',
+  'linux-x64': 'eigenx',
+  'win32-x64': 'eigenx.exe',
+  'win32-arm64': 'eigenx.exe'
+};
+
+function getPlatformPackage() {
+  const platform = process.platform;
+  const arch = process.arch;
+  const key = `${platform}-${arch}`;
+
+  return {
+    packageName: PLATFORMS[key],
+    binaryName: BINARY_NAMES[key],
+    platformKey: key
+  };
+}
+
+function validateInstallation() {
+  const { packageName, binaryName, platformKey } = getPlatformPackage();
+
+  if (!packageName) {
+    console.error(`Unsupported platform: ${platformKey}`);
+    console.error('eigenx is only supported on:');
+    console.error('  - macOS (darwin): arm64, x64');
+    console.error('  - Linux: arm64, x64');
+    console.error('  - Windows: x64, arm64');
+    process.exit(1);
+  }
+
+  // Check if the platform-specific binary exists
+  const binaryPath = join(__dirname, 'node_modules', packageName, 'bin', binaryName);
+
+  if (!existsSync(binaryPath)) {
+    console.error(`Failed to install @layr-labs/eigenx for ${platformKey}`);
+    console.error(`Expected binary at: ${binaryPath}`);
+    console.error('');
+    console.error('This may happen if:');
+    console.error('  1. The platform-specific package failed to install');
+    console.error('  2. Your platform is not supported');
+    console.error('');
+    console.error('Please report this issue at: https://github.com/Layr-Labs/eigenx-cli/issues');
+    process.exit(1);
+  }
+
+  console.log(`✓ @layr-labs/eigenx installed successfully for ${platformKey}`);
+}
+
+validateInstallation();

--- a/npm/eigenx/package.json
+++ b/npm/eigenx/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@layr-labs/eigenx",
+  "version": "0.0.0-development",
+  "description": "CLI toolkit for scaffolding, developing, and testing applications on EigenX",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Layr-Labs/eigenx-cli.git"
+  },
+  "license": "MIT",
+  "bin": {
+    "eigenx": "run.js"
+  },
+  "scripts": {
+    "postinstall": "node install.js"
+  },
+  "optionalDependencies": {
+    "@layr-labs/eigenx-darwin-amd64": "0.0.0-development",
+    "@layr-labs/eigenx-darwin-arm64": "0.0.0-development",
+    "@layr-labs/eigenx-linux-amd64": "0.0.0-development",
+    "@layr-labs/eigenx-linux-arm64": "0.0.0-development",
+    "@layr-labs/eigenx-windows-amd64": "0.0.0-development",
+    "@layr-labs/eigenx-windows-arm64": "0.0.0-development"
+  },
+  "files": [
+    "install.js",
+    "run.js",
+    "README.md"
+  ],
+  "keywords": [
+    "eigenx",
+    "cli",
+    "tee",
+    "docker",
+    "blockchain"
+  ],
+  "engines": {
+    "node": ">=14.0.0"
+  }
+}

--- a/npm/eigenx/run.js
+++ b/npm/eigenx/run.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+const { spawn } = require('child_process');
+const { join } = require('path');
+const { existsSync } = require('fs');
+
+// Map Node.js platform/arch to package names
+const PLATFORMS = {
+  'darwin-arm64': '@layr-labs/eigenx-darwin-arm64',
+  'darwin-x64': '@layr-labs/eigenx-darwin-amd64',
+  'linux-arm64': '@layr-labs/eigenx-linux-arm64',
+  'linux-x64': '@layr-labs/eigenx-linux-amd64',
+  'win32-x64': '@layr-labs/eigenx-windows-amd64',
+  'win32-arm64': '@layr-labs/eigenx-windows-arm64'
+};
+
+// Map platform to binary extension
+const BINARY_NAMES = {
+  'darwin-arm64': 'eigenx',
+  'darwin-x64': 'eigenx',
+  'linux-arm64': 'eigenx',
+  'linux-x64': 'eigenx',
+  'win32-x64': 'eigenx.exe',
+  'win32-arm64': 'eigenx.exe'
+};
+
+function getBinaryPath() {
+  const platform = process.platform;
+  const arch = process.arch;
+  const key = `${platform}-${arch}`;
+
+  const packageName = PLATFORMS[key];
+  const binaryName = BINARY_NAMES[key];
+
+  if (!packageName || !binaryName) {
+    console.error(`Unsupported platform: ${key}`);
+    process.exit(1);
+  }
+
+  const binaryPath = join(__dirname, 'node_modules', packageName, 'bin', binaryName);
+
+  if (!existsSync(binaryPath)) {
+    console.error(`eigenx binary not found at: ${binaryPath}`);
+    console.error('Please try reinstalling: npm install -g @layr-labs/eigenx');
+    process.exit(1);
+  }
+
+  return binaryPath;
+}
+
+function run() {
+  const binaryPath = getBinaryPath();
+  const args = process.argv.slice(2);
+
+  const child = spawn(binaryPath, args, {
+    stdio: 'inherit',
+    windowsHide: false
+  });
+
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+    } else {
+      process.exit(code);
+    }
+  });
+
+  // Forward signals to child process
+  process.on('SIGINT', () => {
+    child.kill('SIGINT');
+  });
+
+  process.on('SIGTERM', () => {
+    child.kill('SIGTERM');
+  });
+}
+
+run();


### PR DESCRIPTION
Adds npm as a distribution channel for eigenx CLI using platform-specific optional dependencies pattern.

**Changes:**
  - Created main package `@layr-labs/eigenx` with 6 platform-specific packages
  - Integrated npm publishing into CI workflows (reuses existing binaries)
  - Dev releases publish with `@dev` tag, prod releases with `@latest`
  - Users can install via `npm install -g @layr-labs/eigenx` or use `npx @layr-labs/eigenx`

**Implementation:**
  - Uses `optionalDependencies` with `os`/`cpu` filtering (npm only downloads matching platform)
  - Platform packages: darwin-arm64, darwin-amd64, linux-arm64, linux-amd64, windows-amd64, windows-arm64
  - Added `npm-prepare`, `npm-publish-prod`, and `npm-publish-dev` Makefile targets
  - Updated release workflows to publish to npm after S3 uploads

**Requires:**
  - `NPM_TOKEN` secret for publishing